### PR TITLE
added "HeadingX" option for style

### DIFF
--- a/src/docx2md/converter.py
+++ b/src/docx2md/converter.py
@@ -108,6 +108,10 @@ class Converter:
             return
 
         style = pStyle.attrib["val"]
+        # im having issues with this as style comes as "Heading<digit>"
+        # maybe not pure MS-docx but google-worksuite generated docx?
+        if "Heading" in style:
+            style = style.replace("Heading", "")
         if style.isdigit():
             print("#" * (int(style)), sub_text, file=of)
         elif style[0] == "a":
@@ -297,3 +301,4 @@ class Converter:
     def emit_image(self, of, id):
         tag_id = f"image{self.image_counter()}"
         print(f'<img src="{self.media[id].alt_path}" id="{tag_id}">', end="", file=of)
+


### PR DESCRIPTION
Hi!

Using the docx2md tool with docx files exported from google worksuite i had no heading being converted to markdown. 
Those come tagged with style="Heading[1|2|3...]" instead of a single digit as the code expects, so i had to remove the "Heading" part from the style value to make it work
